### PR TITLE
Buffered chunks

### DIFF
--- a/benchmark/main.js
+++ b/benchmark/main.js
@@ -14,24 +14,24 @@ const add = (name, fn) => {
 /**
  * .encode()
  */
-/*
+
 const msg1 = [Buffer.from('foo'), Buffer.from('bar')];
 
 add('.encode()', () => {
     fmsg.encode(msg1);
 });
-*/
+
 
 /**
  * .decode()
  */
-/*
+
 const bin1 = fmsg.encode([Buffer.from('foo'), Buffer.from('bar')]);
 
 add('.decode()', () => {
     fmsg.decode(bin1);
 });
-*/
+
 
 /**
  * DecodeStream()
@@ -42,10 +42,10 @@ const message = new fmsg.DecodeStream();
 message.pipe(new stream.Writable({
     objectMode: true,
     write: (chunk, enc, next) => {
-        //console.log('chunk', chunk)
+        // console.log('chunk', chunk)
         next();
     }
-}))
+}));
 
 add('.decodeStream()', () => {
     message.write(bin2);

--- a/benchmark/main.js
+++ b/benchmark/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const benchmark = require('benchmark');
+const stream = require('stream');
 const fmsg = require('../');
 
 const suite = new benchmark.Suite();
@@ -13,24 +14,24 @@ const add = (name, fn) => {
 /**
  * .encode()
  */
-
+/*
 const msg1 = [Buffer.from('foo'), Buffer.from('bar')];
 
 add('.encode()', () => {
     fmsg.encode(msg1);
 });
-
+*/
 
 /**
  * .decode()
  */
-
+/*
 const bin1 = fmsg.encode([Buffer.from('foo'), Buffer.from('bar')]);
 
 add('.decode()', () => {
     fmsg.decode(bin1);
 });
-
+*/
 
 /**
  * DecodeStream()
@@ -38,6 +39,13 @@ add('.decode()', () => {
 
 const bin2 = fmsg.encode([Buffer.from('foo'), Buffer.from('bar')]);
 const message = new fmsg.DecodeStream();
+message.pipe(new stream.Writable({
+    objectMode: true,
+    write: (chunk, enc, next) => {
+        //console.log('chunk', chunk)
+        next();
+    }
+}))
 
 add('.decodeStream()', () => {
     message.write(bin2);

--- a/examples/net.js
+++ b/examples/net.js
@@ -1,17 +1,19 @@
 'use strict';
 
+const stream = require('stream');
 const fmsg = require('../');
 const net = require('net');
 
 // Socket server
 net.createServer((socket) => {
     const msg = new fmsg.DecodeStream();
-
-    msg.on('data', (message) => {
-        console.log(message[0].toString(), message[1].toString(), message[2].toString());
-    });
-
-    socket.pipe(msg);
+    socket.pipe(msg).pipe(new stream.Writable({
+        objectMode: true,
+        write: (chnk, enc, next) => {
+            console.log(chnk[0].toString(), chnk[1].toString(), chnk[2].toString());
+            next();
+        }
+    }));
 }).listen(3000);
 
 

--- a/lib/stream-decode.js
+++ b/lib/stream-decode.js
@@ -93,7 +93,6 @@ const FramedMsgDecodeStream = class FramedMsgDecodeStream extends stream.Transfo
                 this.argc--;
 
                 this.step = 'frame';
-
             } else if (this.step === 'buf' && (length - this.off) >= this.argl) {
                 // part of argument is within chunk
                 // we have buffered up the whole argument
@@ -107,7 +106,6 @@ const FramedMsgDecodeStream = class FramedMsgDecodeStream extends stream.Transfo
                 this.bufv = [];
                 this.bufl = 0;
                 this.step = 'frame';
-
             } else {
                 // the argument is larger then the chunk
                 // we need to buffer up the rest of the argument

--- a/lib/stream-decode.js
+++ b/lib/stream-decode.js
@@ -2,8 +2,6 @@
 
 const stream = require('stream');
 
-const _zero = Symbol('_zero');
-
 const FramedMsgDecodeStream = class FramedMsgDecodeStream extends stream.Transform {
     constructor(args) {
         super(Object.assign({
@@ -61,18 +59,10 @@ const FramedMsgDecodeStream = class FramedMsgDecodeStream extends stream.Transfo
         return 'FramedMsgDecodeStream';
     }
 
-    [_zero]() {
-        this.argc = 0;
-        this.argl = 0;
-        this.argv = [];
-        this.off = 0;
-        this.bufv = [];
-        this.bufl = 0;
-        this.step = 'head';
-    }
-
     _transform(chunk, encoding, next) {
-        if (this.step !== 'buf' && chunk.length < 5) {
+        const length = chunk.length;
+
+        if (this.step !== 'buf' && length < 5) {
             this.emit('error', new RangeError('Chunk is too small. Can not be a proper framed message.'));
             return next();
         }
@@ -85,24 +75,26 @@ const FramedMsgDecodeStream = class FramedMsgDecodeStream extends stream.Transfo
             if (this.step === 'head') {
                 this.argc = chunk.readInt8(0);
                 this.off += 1;
-                this.step = 'size';
+                this.step = 'frame';
             }
 
-            // Get size of following argument
-            if (this.step === 'size') {
+            // Read frame and get size of following argument
+            if (this.step === 'frame') {
                 this.argl = chunk.readUInt32BE(this.off);
                 this.off += 4;
                 this.step = 'arg';
             }
 
             // Get argument
-            if (this.step === 'arg' && (chunk.length - this.off) >= this.argl) {
+            if (this.step === 'arg' && (length - this.off) >= this.argl) {
                 // whole argument is within chunk
                 // we can extract the whole argument from this chunk
                 this.argv.push(chunk.slice(this.off, this.off += this.argl));
-                c = this.argv.length !== this.argc;
-                this.step = 'size';
-            } else if (this.step === 'buf' && (chunk.length - this.off) >= this.argl) {
+                this.argc--;
+
+                this.step = 'frame';
+
+            } else if (this.step === 'buf' && (length - this.off) >= this.argl) {
                 // part of argument is within chunk
                 // we have buffered up the whole argument
                 const chnk = chunk.slice(this.off, this.off += this.argl);
@@ -110,28 +102,39 @@ const FramedMsgDecodeStream = class FramedMsgDecodeStream extends stream.Transfo
                 this.bufl += chnk.length;
 
                 this.argv.push(Buffer.concat(this.bufv, this.bufl));
+                this.argc--;
 
                 this.bufv = [];
                 this.bufl = 0;
-                c = this.argv.length !== this.argc;
-                this.step = 'size';
+                this.step = 'frame';
+
             } else {
                 // the argument is larger then the chunk
                 // we need to buffer up the rest of the argument
-                const chnk = chunk.slice(this.off, chunk.length);
+                const chnk = chunk.slice(this.off, length);
                 this.bufv.push(chnk);
                 this.bufl += chnk.length;
 
-                this.argl -= chunk.length - this.off;
-                this.off = 0;
-                c = false;
+                this.argl -= length - this.off;
+
+                this.off = length;
                 this.step = 'buf';
             }
 
+            // At end of stream chunk
+            if (this.off === length) {
+                this.off = 0;
+                c = false;
+            }
+
             // At end of message
-            if (this.argv.length === this.argc) {
+            if (this.argc === 0) {
                 this.push(this.argv);
-                this[_zero]();
+
+                this.argc = 0;
+                this.argl = 0;
+                this.argv = [];
+                this.step = 'head';
             }
         } while (c);
 

--- a/test/main.js
+++ b/test/main.js
@@ -56,7 +56,33 @@ tap.test('.decodeStream() - object type - should be FramedMsg', (t) => {
     t.end();
 });
 
-tap.test('.decodeStream() - write encoded messages on stream - should emit buffer on data event', (t) => {
+tap.test('.decodeStream() - write one messages with one argument on stream - should emit one message with one argument', (t) => {
+    const msg = new fmsg.DecodeStream();
+    const buf = fmsg.encode([Buffer.from('foo')]);
+
+    msg.on('data', (message) => {
+        t.equal(message.length, 1);
+        t.equal(message[0].toString(), 'foo');
+        t.end();
+    });
+
+    msg.write(buf);
+});
+
+tap.test('.decodeStream() - write one messages with multiple arguments on stream - should emit one message with multiple arguments', (t) => {
+    const msg = new fmsg.DecodeStream();
+    const buf = fmsg.encode([Buffer.from('foo'), Buffer.from('bar'), Buffer.from('xyz')]);
+
+    msg.on('data', (message) => {
+        t.equal(message.length, 3);
+        t.equal(message[0].toString(), 'foo');
+        t.end();
+    });
+
+    msg.write(buf);
+});
+
+tap.test('.decodeStream() - write multiple messages on stream - should emit multiple messages', (t) => {
     const msg = new fmsg.DecodeStream();
 
     const a = fmsg.encode([Buffer.from('foo')]);
@@ -107,7 +133,6 @@ tap.test('.decodeStream() - message holds only head and one frame, no argument -
 
     msg.write(a);
 });
-
 
 tap.test('.decodeStream() - message spreads over multiple stream chunks - should emit message event for each message', (t) => {
     const msg = new fmsg.DecodeStream();
@@ -165,4 +190,45 @@ tap.test('.decodeStream() - one large buffer - should emit one message', (t) => 
     });
 
     msg.write(a);
+});
+
+
+tap.test('.decodeStream() - multiple messages in one chunk - should emit multiple messages', (t) => {
+    const msg = new fmsg.DecodeStream();
+
+    const a = fmsg.encode([Buffer.from('a-foo'), Buffer.from('a-bar'), Buffer.from('a-xyz')]);
+    const b = fmsg.encode([Buffer.from('b-foo'), Buffer.from('b-bar'), Buffer.from('b-xyz')]);
+    const c = fmsg.encode([Buffer.from('c-foo'), Buffer.from('c-bar'), Buffer.from('c-xyz')]);
+
+    let n = 0;
+
+    msg.on('data', (message) => {
+        if (n === 0) {
+            t.equal(message.length, 3);
+            t.equal(message[0].toString(), 'a-foo');
+            t.equal(message[1].toString(), 'a-bar');
+            t.equal(message[2].toString(), 'a-xyz');
+            n++;
+            return;
+        }
+
+        if (n === 1) {
+            t.equal(message.length, 3);
+            t.equal(message[0].toString(), 'b-foo');
+            t.equal(message[1].toString(), 'b-bar');
+            t.equal(message[2].toString(), 'b-xyz');
+            n++;
+            return;
+        }
+
+        if (n === 2) {
+            t.equal(message.length, 3);
+            t.equal(message[0].toString(), 'c-foo');
+            t.equal(message[1].toString(), 'c-bar');
+            t.equal(message[2].toString(), 'c-xyz');
+            t.end();
+        }
+    });
+
+    msg.write(Buffer.concat([a,b,c]));
 });

--- a/test/main.js
+++ b/test/main.js
@@ -230,5 +230,5 @@ tap.test('.decodeStream() - multiple messages in one chunk - should emit multipl
         }
     });
 
-    msg.write(Buffer.concat([a,b,c]));
+    msg.write(Buffer.concat([a, b, c]));
 });


### PR DESCRIPTION
Fixed an issue that a chunk in a stream can contain multiple messages in one chunk. This is typically something which happens ex in the `net` module if messages are small. Then optimization kicks in to save bandwith and data are grouped into chunks.